### PR TITLE
GitHub Actions の各アクションを最新版へ更新 (Node.js 24 対応)

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -18,19 +18,19 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
           bundler-cache: true
-      - uses: actions/configure-pages@v3
+      - uses: actions/configure-pages@v6
         id: pages
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './_site'
 
@@ -43,4 +43,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 背景

直近のデプロイで、Actions Runner から以下の警告が出ている:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/configure-pages@v3, actions/upload-artifact@v4.

- **2026-06-02**: Node.js 24 がデフォルトに切り替わる
- **2026-09-16**: Node.js 20 がランナーから削除

## 変更内容

`.github/workflows/jekyll.yml` で使用している各 action を最新メジャーバージョンへ更新:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/configure-pages` | v3 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`ruby/setup-ruby@v1` は最新もv1系のため変更なし。

## Test plan

- [ ] このPR上でActionsワークフローが成功すること (build / deploy 両ジョブ)
- [ ] Node.js 20 deprecation warning が消えること
- [ ] mainマージ後、GitHub Pages のデプロイ成功 / サイトが正常に表示されること

参考: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)